### PR TITLE
fix resource naming

### DIFF
--- a/environment/infrastructure/firewall.tf
+++ b/environment/infrastructure/firewall.tf
@@ -2,7 +2,7 @@ locals {
   firewall_rules = {
     # Allow SSH access via IAP (Identity-Aware Proxy)
     "allow-iap-ssh" = {
-      description   = "Allow SSH access via Identity-Aware Proxy"
+      description   = format("Allow SSH access via Identity-Aware Proxy for %s", local.vcluster_name)
       source_ranges = ["35.235.240.0/20"] # IAP source ranges
       target_tags   = ["allow-iap-ssh"]
       direction     = "INGRESS"
@@ -14,7 +14,7 @@ locals {
     }
     # Allow HTTP/HTTPS traffic for public instances
     "allow-web-traffic" = {
-      description   = "Allow HTTP and HTTPS traffic"
+      description   = format("Allow HTTP and HTTPS traffic for %s", local.vcluster_name)
       source_ranges = ["0.0.0.0/0"]
       direction     = "INGRESS"
       allow = [{
@@ -24,7 +24,7 @@ locals {
     }
     # Allow internal communication between subnets
     "allow-internal" = {
-      description   = "Allow internal communication within VPC"
+      description   = format("Allow internal communication within VPC for %s", local.vcluster_name)
       source_ranges = [local.public_subnet_cidr, local.private_subnet_cidr]
       direction     = "INGRESS"
       allow = [
@@ -44,7 +44,7 @@ locals {
     },
     # Allow health checks from Google Cloud Load Balancer
     "allow-health-check" = {
-      description   = "Allow health checks from Google Cloud Load Balancer"
+      description   = format("Allow health checks from Google Cloud Load Balancer for %s", local.vcluster_name)
       priority      = 1000
       source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
       direction     = "INGRESS"
@@ -60,7 +60,7 @@ resource "google_compute_firewall" "rules" {
   for_each = local.firewall_rules
 
   project     = local.project
-  name        = format("%s-%s", local.vcluster_unique_name, each.key)
+  name        = format("%s-%s", each.key, local.random_id)
   network     = module.vpc[local.project_region_key].network_self_link
   description = each.value.description
   direction   = each.value.direction

--- a/environment/infrastructure/iam.tf
+++ b/environment/infrastructure/iam.tf
@@ -1,8 +1,8 @@
 resource "google_service_account" "vcluster_node" {
   project      = local.project
-  account_id   = format("%s-node", local.vcluster_unique_name)
-  display_name = format("vCluster node role for %s", local.vcluster_unique_name)
-  description  = "Used by Kubernetes nodes (IMDS tokens) for CCM/CSI"
+  account_id   = format("vcluster-node-sa-%s", local.random_id)
+  display_name = format("Node service account for %s", local.vcluster_name)
+  description  = format("Needed by Kubernetes nodes to obtain IMDS tokens for CCM/CSI, used by %s", local.vcluster_name)
 }
 
 ###################
@@ -26,9 +26,9 @@ resource "google_project_iam_custom_role" "ccm_firewall_min" {
   for_each = local.ccm_enabled ? { enabled = true } : {}
 
   project     = local.project
-  role_id     = replace(format("%s-ccm-firewall-min", local.vcluster_unique_name), "-", "_")
-  title       = format("%s CCM firewall minimal", local.vcluster_unique_name)
-  description = "Minimal VPC firewall permissions for cloud-provider-gcp"
+  role_id     = replace(format("ccm-firewall-%s", local.random_id), "-", "_")
+  title       = format("CCM firewall for %s", local.vcluster_name)
+  description = format("Minimal VPC firewall permissions for CCM, used by %s", local.vcluster_name)
   permissions = [
     "compute.firewalls.create",
     "compute.firewalls.delete",

--- a/environment/infrastructure/main.tf
+++ b/environment/infrastructure/main.tf
@@ -27,7 +27,8 @@ module "vpc" {
   version = "~> 11.1"
 
   project_id   = local.project
-  network_name = local.vcluster_unique_name
+  network_name = format("vcluster-network-%s", local.random_id)
+  description  = format("Network for %s", local.vcluster_name)
 
   subnets = [
     {
@@ -53,8 +54,8 @@ module "cloud_nat" {
 
   project_id                         = local.project
   region                             = local.region
-  name                               = format("%s-nat", local.vcluster_unique_name)
-  router                             = format("%s-router", local.vcluster_unique_name)
+  name                               = format("vcluster-nat-%s", local.random_id)
+  router                             = format("vcluster-router-%s", local.random_id)
   create_router                      = true
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
   network                            = module.vpc[local.project_region_key].network_self_link

--- a/environment/kubernetes/locals.tf
+++ b/environment/kubernetes/locals.tf
@@ -5,6 +5,8 @@ locals {
   vcluster_name      = nonsensitive(var.vcluster.instance.metadata.name)
   node_provider_name = nonsensitive(var.vcluster.nodeProvider.metadata.name)
 
+  suffix = substr(md5(format("%s%s", local.node_provider_name, local.vcluster_name)), 0, 8)
+
   ccm_enabled    = try(tobool(var.vcluster.properties["vcluster.com/ccm-enabled"]), true)
   ccm_lb_enabled = try(tobool(var.vcluster.properties["vcluster.com/ccm-lb-enabled"]), true)
   csi_enabled    = try(tobool(var.vcluster.properties["vcluster.com/csi-enabled"]), true)

--- a/environment/kubernetes/main.tf
+++ b/environment/kubernetes/main.tf
@@ -9,6 +9,7 @@ module "kubernetes_apply_ccm" {
 
   manifest_file = "${path.module}/manifests/ccm.yaml.tftpl"
   template_vars = {
+    suffix             = local.suffix
     network_name       = local.network_name
     subnet_name        = local.subnet_name
     vcluster_name      = local.vcluster_name
@@ -31,6 +32,7 @@ module "kubernetes_apply_csi" {
   computed_fields = ["globalDefault"]
 
   template_vars = {
+    suffix             = local.suffix
     node_provider_name = local.node_provider_name
     availability_zones = jsonencode(local.availability_zones)
   }

--- a/environment/kubernetes/manifests/ccm.yaml.tftpl
+++ b/environment/kubernetes/manifests/ccm.yaml.tftpl
@@ -2,17 +2,21 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ${node_provider_name}-cloud-controller-manager
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: gcp-cloud-controller-manager-${suffix}
   namespace: kube-system
   labels:
-    app.kubernetes.io/name: ${node_provider_name}-cloud-controller-manager
+    app.kubernetes.io/name: gcp-cloud-controller-manager-${suffix}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:${node_provider_name}-cloud-controller-manager
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: gcp-cloud-controller-manager-${suffix}
   labels:
-    app.kubernetes.io/name: ${node_provider_name}-cloud-controller-manager
+    app.kubernetes.io/name: gcp-cloud-controller-manager-${suffix}
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -51,38 +55,44 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: ${node_provider_name}-cloud-controller-manager:apiserver-authentication-reader
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: gcp-cloud-controller-manager-${suffix}-api-auth
   namespace: kube-system
   labels:
-    app.kubernetes.io/name: ${node_provider_name}-cloud-controller-manager
+    app.kubernetes.io/name: gcp-cloud-controller-manager-${suffix}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: extension-apiserver-authentication-reader
 subjects:
   - kind: ServiceAccount
-    name: ${node_provider_name}-cloud-controller-manager
+    name: gcp-cloud-controller-manager-${suffix}
     namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:${node_provider_name}-cloud-controller-manager
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: gcp-cloud-controller-manager-${suffix}
   labels:
-    app.kubernetes.io/name: ${node_provider_name}-cloud-controller-manager
+    app.kubernetes.io/name: gcp-cloud-controller-manager-${suffix}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:${node_provider_name}-cloud-controller-manager
+  name: gcp-cloud-controller-manager-${suffix}
 subjects:
   - kind: ServiceAccount
-    name: ${node_provider_name}-cloud-controller-manager
+    name: gcp-cloud-controller-manager-${suffix}
     namespace: kube-system
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ${node_provider_name}-cloud-config
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: gcp-cloud-config-${suffix}
   namespace: kube-system
 data:
   cloud-config: |
@@ -94,26 +104,28 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${node_provider_name}-cloud-controller-manager
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: gcp-cloud-controller-manager-${suffix}
   namespace: kube-system
   labels:
-    app.kubernetes.io/name: ${node_provider_name}-cloud-controller-manager
+    app.kubernetes.io/name: gcp-cloud-controller-manager-${suffix}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: ${node_provider_name}-cloud-controller-manager
+      app.kubernetes.io/name: gcp-cloud-controller-manager-${suffix}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: ${node_provider_name}-cloud-controller-manager
+        app.kubernetes.io/name: gcp-cloud-controller-manager-${suffix}
         tier: control-plane
     spec:
       hostNetwork: true
       dnsPolicy: Default
       nodeSelector:
         vcluster.loft.sh/node-provider: ${node_provider_name}
-      serviceAccountName: ${node_provider_name}-cloud-controller-manager
+      serviceAccountName: gcp-cloud-controller-manager-${suffix}
       priorityClassName: system-cluster-critical
       tolerations:
         - key: node.cloudprovider.kubernetes.io/uninitialized
@@ -149,7 +161,7 @@ spec:
             - --leader-elect-resource-lock=leases
             - --cluster-name=${vcluster_name}
             - --cloud-config=/etc/kubernetes/cloud-config
-            - --leader-elect-resource-name=${node_provider_name}-cloud-controller-manager
+            - --leader-elect-resource-name=gcp-cloud-controller-manager-${suffix}
           livenessProbe:
             httpGet:
               scheme: HTTPS
@@ -169,7 +181,7 @@ spec:
       volumes:
         - name: cloud-config
           configMap:
-            name: ${node_provider_name}-cloud-config
+            name: gcp-cloud-config-${suffix}
             items:
               - key: cloud-config
                 path: cloud-config

--- a/environment/kubernetes/manifests/csi.yaml.tftpl
+++ b/environment/kubernetes/manifests/csi.yaml.tftpl
@@ -1,27 +1,27 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-controller-sa
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-controller-sa-${suffix}
   namespace: kube-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-node-sa
-  namespace: kube-system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ${node_provider_name}-csi-gce-pd-node-sa-win
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-node-sa-${suffix}
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
   labels:
-    k8s-app: ${node_provider_name}-compute-persistent-disk-csi-driver
-  name: ${node_provider_name}-csi-gce-pd-leaderelection-role
+    k8s-app: gcp-compute-persistent-disk-csi-driver-${suffix}
+  name: csi-gce-pd-leaderelection-role-${suffix}
   namespace: kube-system
 rules:
 - apiGroups:
@@ -39,7 +39,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-attacher-role
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-attacher-role-${suffix}
 rules:
 - apiGroups:
   - ""
@@ -87,7 +89,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-node-deploy
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-node-deploy-${suffix}
 rules:
 - apiGroups:
   - ""
@@ -100,7 +104,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-provisioner-role
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-provisioner-role-${suffix}
 rules:
 - apiGroups:
   - ""
@@ -189,7 +195,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-resizer-role
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-resizer-role-${suffix}
 rules:
 - apiGroups:
   - ""
@@ -246,7 +254,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-snapshotter-role
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-snapshotter-role-${suffix}
 rules:
 - apiGroups:
   - ""
@@ -289,91 +299,104 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
   labels:
-    k8s-app: ${node_provider_name}-compute-persistent-disk-csi-driver
-  name: ${node_provider_name}-csi-gce-pd-controller-leaderelection-binding
+    k8s-app: gcp-compute-persistent-disk-csi-driver-${suffix}
+  name: csi-gce-pd-controller-leaderelection-binding-${suffix}
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: ${node_provider_name}-csi-gce-pd-leaderelection-role
+  name: csi-gce-pd-leaderelection-role-${suffix}
 subjects:
 - kind: ServiceAccount
-  name: ${node_provider_name}-csi-gce-pd-controller-sa
+  name: csi-gce-pd-controller-sa-${suffix}
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-controller-attacher-binding
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-controller-attacher-binding-${suffix}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ${node_provider_name}-csi-gce-pd-attacher-role
+  name: csi-gce-pd-attacher-role-${suffix}
 subjects:
 - kind: ServiceAccount
-  name: ${node_provider_name}-csi-gce-pd-controller-sa
+  name: csi-gce-pd-controller-sa-${suffix}
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-controller-provisioner-binding
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-controller-provisioner-binding-${suffix}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ${node_provider_name}-csi-gce-pd-provisioner-role
+  name: csi-gce-pd-provisioner-role-${suffix}
 subjects:
 - kind: ServiceAccount
-  name: ${node_provider_name}-csi-gce-pd-controller-sa
+  name: csi-gce-pd-controller-sa-${suffix}
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-controller-snapshotter-binding
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-controller-snapshotter-binding-${suffix}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ${node_provider_name}-csi-gce-pd-snapshotter-role
+  name: csi-gce-pd-snapshotter-role-${suffix}
 subjects:
 - kind: ServiceAccount
-  name: ${node_provider_name}-csi-gce-pd-controller-sa
+  name: csi-gce-pd-controller-sa-${suffix}
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-node
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-node-${suffix}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ${node_provider_name}-csi-gce-pd-node-deploy
+  name: csi-gce-pd-node-deploy-${suffix}
 subjects:
 - kind: ServiceAccount
-  name: ${node_provider_name}-csi-gce-pd-node-sa
+  name: csi-gce-pd-node-sa-${suffix}
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-resizer-binding
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-resizer-binding-${suffix}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ${node_provider_name}-csi-gce-pd-resizer-role
+  name: csi-gce-pd-resizer-role-${suffix}
 subjects:
 - kind: ServiceAccount
-  name: ${node_provider_name}-csi-gce-pd-controller-sa
+  name: csi-gce-pd-controller-sa-${suffix}
   namespace: kube-system
 ---
 apiVersion: scheduling.k8s.io/v1
-description: This priority class should be used for the GCE PD CSI driver controller
-  deployment only.
+description: This priority class should be used for the GCE PD CSI driver controller deployment only.
 globalDefault: false
 kind: PriorityClass
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-controller
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-controller-${suffix}
 value: 900000000
 ---
 apiVersion: scheduling.k8s.io/v1
@@ -381,23 +404,27 @@ description: This priority class should be used for the GCE PD CSI driver node d
 globalDefault: false
 kind: PriorityClass
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-node
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-node-${suffix}
 value: 900001000
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-controller
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-controller-${suffix}
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ${node_provider_name}-compute-persistent-disk-csi-driver
+      app: gcp-compute-persistent-disk-csi-driver-${suffix}
   template:
     metadata:
       labels:
-        app: ${node_provider_name}-compute-persistent-disk-csi-driver
+        app: gcp-compute-persistent-disk-csi-driver-${suffix}
     spec:
       containers:
       - args:
@@ -527,8 +554,8 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
         vcluster.loft.sh/node-provider: ${node_provider_name}
-      priorityClassName: ${node_provider_name}-csi-gce-pd-controller
-      serviceAccountName: ${node_provider_name}-csi-gce-pd-controller-sa
+      priorityClassName: csi-gce-pd-controller-${suffix}
+      serviceAccountName: csi-gce-pd-controller-sa-${suffix}
       tolerations:
       - key: "vcluster.com/cleanup"
         operator: "Exists"
@@ -540,16 +567,18 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: ${node_provider_name}-csi-gce-pd-node
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: csi-gce-pd-node-${suffix}
   namespace: kube-system
 spec:
   selector:
     matchLabels:
-      app: ${node_provider_name}-compute-persistent-disk-csi-driver
+      app: gcp-compute-persistent-disk-csi-driver-${suffix}
   template:
     metadata:
       labels:
-        app: ${node_provider_name}-compute-persistent-disk-csi-driver
+        app: gcp-compute-persistent-disk-csi-driver-${suffix}
     spec:
       containers:
       - args:
@@ -604,8 +633,8 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
         vcluster.loft.sh/node-provider: ${node_provider_name}
-      priorityClassName: ${node_provider_name}-csi-gce-pd-node
-      serviceAccountName: ${node_provider_name}-csi-gce-pd-node-sa
+      priorityClassName: csi-gce-pd-node-${suffix}
+      serviceAccountName: csi-gce-pd-node-sa-${suffix}
       tolerations:
       - operator: Exists
       volumes:
@@ -649,6 +678,8 @@ spec:
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
   name: pd.csi.storage.gke.io
 spec:
   attachRequired: true
@@ -658,7 +689,9 @@ spec:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: ${node_provider_name}-csi-gce-pd
+  annotations:
+    vcluster.loft.sh/node-provider: ${node_provider_name}
+  name: ${node_provider_name}-disk-default
 provisioner: pd.csi.storage.gke.io
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true


### PR DESCRIPTION
The PR changes the resource naming in the terraform environment to the `<resource-name>-<computed-hash> ` pattern.
Additionally, I replaced` vcluster.com/public-subnet-cidr` and `vcluster.com/private-subnet-cidr` with a single `vcluster.com/vpc-cidr`, subnets are now calculated automatically.

Part of ENG-9544