### PR TITLE
remove allowed topology from standard storage class

### DIFF
--- a/environment/infrastructure/main.tf
+++ b/environment/infrastructure/main.tf
@@ -24,7 +24,7 @@ module "vpc" {
   for_each = { (local.project_region_key) = true }
 
   source  = "terraform-google-modules/network/google"
-  version = "~> 11.1"
+  version = "~> 12.0.0"
 
   project_id   = local.project
   network_name = format("vcluster-network-%s", local.random_id)
@@ -50,7 +50,7 @@ module "cloud_nat" {
   for_each = { (local.project_region_key) = true }
 
   source  = "terraform-google-modules/cloud-nat/google"
-  version = "~> 5.0"
+  version = "~> 5.4.0"
 
   project_id                         = local.project
   region                             = local.region

--- a/environment/kubernetes/main.tf
+++ b/environment/kubernetes/main.tf
@@ -34,6 +34,5 @@ module "kubernetes_apply_csi" {
   template_vars = {
     suffix             = local.suffix
     node_provider_name = local.node_provider_name
-    availability_zones = jsonencode(local.availability_zones)
   }
 }

--- a/environment/kubernetes/manifests/csi.yaml.tftpl
+++ b/environment/kubernetes/manifests/csi.yaml.tftpl
@@ -697,12 +697,3 @@ volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
   csi.storage.k8s.io/fstype: ext4
-%{ if length(jsondecode(availability_zones)) > 0 ~}
-allowedTopologies:
-- matchLabelExpressions:
-  - key: topology.gke.io/zone
-    values:
-%{ for az in jsondecode(availability_zones) ~}
-    - ${az}
-%{ endfor ~}
-%{ endif ~}

--- a/node/main.tf
+++ b/node/main.tf
@@ -17,7 +17,7 @@ resource "random_id" "vm_suffix" {
 
 module "private_instance" {
   source  = "terraform-google-modules/vm/google//modules/compute_instance"
-  version = "~> 13.0"
+  version = "~> 13.6.0"
 
   region            = local.region
   zone              = local.zone == "" ? null : local.zone
@@ -49,7 +49,7 @@ data "google_compute_image" "img" {
 
 module "instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
-  version = "~> 13.0"
+  version = "~> 13.6.0"
 
   region             = local.region
   project_id         = local.project


### PR DESCRIPTION
Dynamic node pools with CSI topology don't work perfectly.
There is race condition between Karpenter and CSI driver, both try to manage `topology.gke.io/zone`.
